### PR TITLE
stm32l0 family has correct hal_dependency features

### DIFF
--- a/pre-script.rhai
+++ b/pre-script.rhai
@@ -487,7 +487,7 @@ hal_dependency += "\n";
 hal_dependency += "features = [";
 // TODO: fix features
 if chipfamily == "stm32l0" {
-    hal_dependency += `"mcu-${CHIP}", `;
+    hal_dependency += `"mcu-${probe_rs_chip}", `;
 } else if chipfamily == "stm32f3" {
     let feature = chipserie + 'x' + flash_lit.to_lower();
     hal_dependency += `"${feature}", `;


### PR DESCRIPTION
`pre-script.rhai` needs to establish a value for the Liquid variable `hal_dependency`. 
For the chipfamily `stm32l0`, it was attempting to interpolate a rhai variable named `CHIP`, which is not defined (`CHIP` will shortly be set as a Liquid variable from the rhai variable `probe_rs_chip`) and so fails.
This change interpolates the rhai variable `probe_rs_chip` instead, achieve the desired result.

I'm not sure whether this amounts to addressing the whole of the `TODO: fix features`, so I have not removed that line.

Edit: corrected the name of `hal_dependency`.