### PR TITLE
Enable out-of-the-box debugging with STM32F411 chip series

### DIFF
--- a/.cargo/config.toml.liquid
+++ b/.cargo/config.toml.liquid
@@ -24,3 +24,4 @@ target = "{{ target }}"
 
 [env]
 {% if defmt_enabled == false %}# {% endif %}DEFMT_LOG = "info"
+CHIPSERIE = "{{chipserie}}"

--- a/.vscode/launch.json.liquid
+++ b/.vscode/launch.json.liquid
@@ -11,6 +11,7 @@
             "cwd": "${workspaceFolder}",
             "coreConfigs": [
                 {
+                    "programBinary": "target/{{ target }}/debug/{{ project-name }}",
                     "coreIndex": 0,
                     "svdFile": "{{ chipserie }}.svd.patched",
                     "rttEnabled": true,
@@ -47,6 +48,7 @@
             "cwd": "${workspaceFolder}",
             "coreConfigs": [
                 {
+                    "programBinary": "target/{{ target }}/release/{{ project-name }}",
                     "coreIndex": 0,
                     "svdFile": "{{ chipserie }}.svd.patched",
                     "rttEnabled": true,

--- a/.vscode/launch.json.liquid
+++ b/.vscode/launch.json.liquid
@@ -2,10 +2,46 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "preLaunchTask": "${defaultBuildTask}",
+            "preLaunchTask": "cargo_build_debug",
             "type": "probe-rs-debug",
             "request": "launch",
             "name": "probe-rs-debugger",
+            // "server": "127.0.0.1:50001", // For connecting to an existing probe-rs-debugger process
+            "chip": "{{ CHIP }}",
+            "cwd": "${workspaceFolder}",
+            "coreConfigs": [
+                {
+                    "coreIndex": 0,
+                    "svdFile": "{{ chipserie }}.svd.patched",
+                    "rttEnabled": true,
+                    "rttChannelFormats": [
+                        {
+                            "dataFormat": "String",
+                            "channelNumber": 0,
+                            "showTimestamps": true
+                        }
+                    ],
+                },
+            ],
+            "runtimeExecutable": "probe-rs",
+            "runtimeArgs": ["dap-server"],
+            "flashingConfig": {
+              "flashingEnabled": true,
+              "haltAfterReset": false,
+              "formatOptions": {
+                "format": "elf" //!MODIFY (or remove). Valid values are: 'bin', 'hex', 'elf'(default), 'idf'
+              }
+            },
+            "connectUnderReset": false,
+            "consoleLogLevel": "Console" //Info, Debug
+            //"speed": 24000, //!MODIFY (or remove)
+            //"probe": "VID:PID:<Serial>", //!MODIFY (or remove)
+        },
+        {
+            "preLaunchTask": "cargo_build_release",
+            "type": "probe-rs-debug",
+            "request": "launch",
+            "name": "probe-rs-release",
             // "server": "127.0.0.1:50001", // For connecting to an existing probe-rs-debugger process
             "chip": "{{ CHIP }}",
             "cwd": "${workspaceFolder}",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,12 +9,34 @@
              * but we need to provide a label for it,
              * so we can invoke it from the debug launcher.
              */
-            "label": "cargo_build",
+            "label": "cargo_build_release",
             "type": "process",
             "command": "cargo",
             "args": [
                 "build",
                 "--release",
+                "--features",
+                "${config:rust-analyzer.cargo.features}"
+            ],
+            "problemMatcher": [
+                "$rustc",
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            /*
+             * This is the default cargo build task,
+             * but we need to provide a label for it,
+             * so we can invoke it from the debug launcher.
+             */
+            "label": "cargo_build_debug",
+            "type": "process",
+            "command": "cargo",
+            "args": [
+                "build",
                 "--features",
                 "${config:rust-analyzer.cargo.features}"
             ],

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ cortex-m-rt = "0.7"
 
 {{ hal_dependency }}
 
+[build-dependencies]
+reqwest = { version = "0.11", features = ["blocking"] }
+
 # Set the default for dependencies.
 [profile.dev.package."*"]
 opt-level = "s"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,38 @@
+use std::env;
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+fn main() {
+    // Retrieve the target chip series from the environment variable
+    let target = env::var("CHIPSERIE").expect("CHIPSERIE not provided");
+
+    let filename = format!("{}.svd.patched", target);
+    let url = format!("https://stm32-rs.github.io/stm32-rs/{}", &filename);
+    let output_path = Path::new(&filename);
+
+    // Check if the file already exists
+    if output_path.exists() {
+        println!(
+            "SVD file already exists at {:?}, skipping download.",
+            output_path
+        );
+    } else {
+        // Ensure the output directory exists
+        if let Some(parent) = output_path.parent() {
+            fs::create_dir_all(parent).expect("Failed to create directory for SVD file");
+        }
+
+        // Download the file
+        println!("Downloading SVD file from {}...", url);
+        let response = reqwest::blocking::get(&url).expect("Failed to fetch SVD file");
+        let content = response.text().expect("Failed to read response body");
+
+        // Write the downloaded content to the file
+        let mut file = fs::File::create(output_path).expect("Failed to create SVD file");
+        file.write_all(content.as_bytes())
+            .expect("Failed to write SVD file");
+
+        println!("SVD file saved to {:?}", output_path);
+    }
+}


### PR DESCRIPTION
## Description  
This PR provides out-of-the-box debugging without requiring any additional configuration. It has been tested with the **STM32F411** chip series.

If needed, this PR can be split into smaller, focused PRs.

## Changes  
- Added two tasks: `release` and `debug`.  
- Auto-complete the `core-config` (`program-binary`) in `release`/`debug`.  
- Auto-download the latest **SVD file** based on the `CHIPSERIES` via `build.rs`.

## Benefits  
These changes make it easier to quickly start a debugger session without the need to manually configure variables or spend time troubleshooting.