### PR TITLE
Fixes issue-17

### DIFF
--- a/build.rs.liquid
+++ b/build.rs.liquid
@@ -10,7 +10,8 @@ fn main() {
     // Retrieve the target chip series from the environment variable
     let target = "{{ svd_chipserie }}.svd";
 
-    let output_path = Path::new(&format!("{target}.svd"));
+    let file_name = format!("{target}.svd");
+    let output_path = Path::new(&file_name);
     let url = format!("https://stm32-rs.github.io/stm32-rs/{target}.patched");
 
     // Check if the file already exists


### PR DESCRIPTION
Fixes #17 

```
error[E0716]: temporary value dropped while borrowed
  --> build.rs:13:34
   |
13 |     let output_path = Path::new(&format!("{target}.svd"));
   |                                  ^^^^^^^^^^^^^^^^^^^^^^^ - temporary value is freed at the end of this statement
   |                                  |
   |                                  creates a temporary value which is freed while still in use
...
17 |     if output_path.exists() {
   |        ----------- borrow later used here
   |
   = note: consider using a `let` binding to create a longer lived value
   = note: this error originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
```

